### PR TITLE
Supress EmptyDSLErrors on skipped tests

### DIFF
--- a/cafe/drivers/unittest/decorators.py
+++ b/cafe/drivers/unittest/decorators.py
@@ -150,8 +150,9 @@ def DataDrivenClass(*dataset_lists):
         unittest_driver_config = DriverConfig()
 
         for i, dataset_list in enumerate(dataset_lists):
-            if (not dataset_list and
-               not unittest_driver_config.ignore_empty_datasets):
+            if all([not dataset_list,
+                    not unittest_driver_config.ignore_empty_datasets,
+                    not getattr(cls, '__unittest_skip__', False)]):
                 # The DSL did not generate anything
                 class_name_new = "{class_name}_{exception}_{index}".format(
                     class_name=class_name,
@@ -163,10 +164,7 @@ def DataDrivenClass(*dataset_lists):
                 # Additionally this should surface any tests that did not run
                 # due to the DSL issue.
                 new_cls = DataDrivenFixture(_FauxDSLFixture)
-                new_class = type(
-                    class_name_new,
-                    (new_cls,),
-                    {})
+                new_class = type(class_name_new, (new_cls,), {})
                 dsl_namespace = cclogging.get_object_namespace(
                     dataset_list.__class__)
                 test_ls = [test for test in dir(cls) if test.startswith(

--- a/cafe/engine/models/data_interfaces.py
+++ b/cafe/engine/models/data_interfaces.py
@@ -140,7 +140,7 @@ class ConfigParserDataSource(DataSource):
     def __init__(self, config_file_path, section_name):
         super(ConfigParserDataSource, self).__init__()
 
-        cafe_env_var = {key: value for key, value in os.environ.iteritems()
+        cafe_env_var = {key: value for key, value in os.environ.items()
                         if key.startswith('CAFE_')}
 
         self._data_source = configparser.SafeConfigParser(

--- a/cafe/plugins/http/cafe/engine/http/client.py
+++ b/cafe/plugins/http/cafe/engine/http/client.py
@@ -105,8 +105,7 @@ def _log_transaction(log, level=cclogging.logging.DEBUG):
                 log.error("An exception occured durring logging")
                 log.exception()
 
-            response_header = '\n{0}\nRESPONSE RECEIVED\n{0}\n'.format(
-                '-' * 17)
+            response_header = '\n{0}\nRESPONSE RECEIVED\n{0}\n'.format('-' * 17)
             logline = ''.join([
                 response_header,
                 'response status..: {0}\n'.format(response),

--- a/cafe/plugins/http/cafe/engine/http/client.py
+++ b/cafe/plugins/http/cafe/engine/http/client.py
@@ -105,7 +105,8 @@ def _log_transaction(log, level=cclogging.logging.DEBUG):
                 log.error("An exception occured durring logging")
                 log.exception()
 
-            response_header = '\n{0}\nRESPONSE RECEIVED\n{0}\n'.format('-' * 17)
+            response_header = '\n{0}\nRESPONSE RECEIVED\n{0}\n'.format(
+                '-' * 17)
             logline = ''.join([
                 response_header,
                 'response status..: {0}\n'.format(response),


### PR DESCRIPTION
 - Prevented `EmptyDSLErrors` from being raised on a `DataDrivenClass`
   that has been skipped.
 - Added metatests for the new functionality.
 - Fixed a random PEP8 error.
 - Fixed a 3.5 support issue.