### PR TITLE
Allow extra showwarning args

### DIFF
--- a/cafe/common/reporting/cclogging.py
+++ b/cafe/common/reporting/cclogging.py
@@ -20,7 +20,8 @@ import os
 import warnings
 warnings.simplefilter('once', Warning)
 warnings.showwarning = \
-    lambda msg, category, filename, lineno, *kwargs: sys.stderr.write(str(msg))
+    lambda msg, category, filename, lineno, *kwargs: sys.stderr.write(
+        str(msg))
 
 try:
     from collections import OrderedDict

--- a/cafe/common/reporting/cclogging.py
+++ b/cafe/common/reporting/cclogging.py
@@ -20,7 +20,7 @@ import os
 import warnings
 warnings.simplefilter('once', Warning)
 warnings.showwarning = \
-    lambda msg, category, filename, lineno: sys.stderr.write(str(msg))
+    lambda msg, category, filename, lineno, *kwargs: sys.stderr.write(str(msg))
 
 try:
     from collections import OrderedDict


### PR DESCRIPTION
Allow for extra args to 'showwarning' for future Python versions 