### PR TITLE
Apply tags and decorators to individual test methods when using DataDrivenClass

### DIFF
--- a/cafe/drivers/unittest/decorators.py
+++ b/cafe/drivers/unittest/decorators.py
@@ -13,6 +13,7 @@
 from importlib import import_module
 from unittest import TestCase
 from warnings import warn, simplefilter
+import functools
 import inspect
 import re
 
@@ -178,14 +179,20 @@ def DataDrivenClass(*dataset_lists):
                 new_class = type(class_name_new, (cls,), dataset.data)
                 new_class.__module__ = cls.__module__
 
-                # Find all test methods on the original class, add tags and other decorators,
+                # Find all test methods, add tags and other decorators,
                 # then set the appropriate test method on the new class
-                for method_name, method in cls.__dict__.items():
-                    if method_name.startswith("test_"):
-                        new_method = method
+                for member_name, member in inspect.getmembers(cls):
+                    if member_name.startswith("test_"):
+                        method_name, original_method = member_name, member
+
+                        @functools.wraps(original_method)
+                        @tags(*dataset.metadata["tags"])
+                        def new_method(*args, **kwargs):
+                            original_method(*args, **kwargs)
+
                         for decorator_ in dataset.metadata["decorators"]:
                             new_method = decorator_(new_method)
-                        new_method = tags(*dataset.metadata["tags"])(new_method)
+
                         setattr(new_class, method_name, new_method)
 
                 setattr(module, class_name_new, new_class)

--- a/cafe/drivers/unittest/decorators.py
+++ b/cafe/drivers/unittest/decorators.py
@@ -177,6 +177,17 @@ def DataDrivenClass(*dataset_lists):
                 class_name_new = "{0}_{1}".format(class_name, dataset.name)
                 new_class = type(class_name_new, (cls,), dataset.data)
                 new_class.__module__ = cls.__module__
+
+                # Find all test methods on the original class, add tags and other decorators,
+                # then set the appropriate test method on the new class
+                for method_name, method in cls.__dict__.items():
+                    if method_name.startswith("test_"):
+                        new_method = method
+                        for decorator_ in dataset.metadata["decorators"]:
+                            new_method = decorator_(new_method)
+                        new_method = tags(*dataset.metadata["tags"])(new_method)
+                        setattr(new_class, method_name, new_method)
+
                 setattr(module, class_name_new, new_class)
         return cls
     return decorator

--- a/cafe/drivers/unittest/decorators.py
+++ b/cafe/drivers/unittest/decorators.py
@@ -189,7 +189,7 @@ def DataDrivenClass(*dataset_lists):
                             @functools.wraps(original_method)
                             @tags(*dataset.metadata["tags"])
                             def new_method(*args, **kwargs):
-                                original_method(*args, **kwargs)
+                                return original_method(*args, **kwargs)
 
                             for decorator_ in dataset.metadata["decorators"]:
                                 new_method = decorator_(new_method)

--- a/cafe/drivers/unittest/decorators.py
+++ b/cafe/drivers/unittest/decorators.py
@@ -179,21 +179,22 @@ def DataDrivenClass(*dataset_lists):
                 new_class = type(class_name_new, (cls,), dataset.data)
                 new_class.__module__ = cls.__module__
 
-                # Find all test methods, add tags and other decorators,
-                # then set the appropriate test method on the new class
-                for member_name, member in inspect.getmembers(cls):
-                    if member_name.startswith("test_"):
-                        method_name, original_method = member_name, member
+                if dataset.metadata["tags"] or dataset.metadata["decorators"]:
+                    # Find all test methods, add tags and other decorators,
+                    # then set the appropriate test method on the new class
+                    for member_name, member in inspect.getmembers(cls):
+                        if member_name.startswith("test_"):
+                            method_name, original_method = member_name, member
 
-                        @functools.wraps(original_method)
-                        @tags(*dataset.metadata["tags"])
-                        def new_method(*args, **kwargs):
-                            original_method(*args, **kwargs)
+                            @functools.wraps(original_method)
+                            @tags(*dataset.metadata["tags"])
+                            def new_method(*args, **kwargs):
+                                original_method(*args, **kwargs)
 
-                        for decorator_ in dataset.metadata["decorators"]:
-                            new_method = decorator_(new_method)
+                            for decorator_ in dataset.metadata["decorators"]:
+                                new_method = decorator_(new_method)
 
-                        setattr(new_class, method_name, new_method)
+                            setattr(new_class, method_name, new_method)
 
                 setattr(module, class_name_new, new_class)
         return cls


### PR DESCRIPTION
Currently, when using `DataDrivenClass`, the decorators and tags provided to each individual dataset (`_Dataset`) are not being applied.

Here is an example:

```py
from cafe.drivers.unittest.datasets import DatasetList
from cafe.drivers.unittest.decorators import tags, DataDrivenClass

class ItemList(DatasetList):
    '''For any datadriven test that needs a list of things/items'''
    def __init__(self, item_iterator):
        super(ItemList, self).__init__()
        for item in item_iterator:
            self.append_new_dataset(item, {'item': item}, tags=["secret-tag"])

@DataDrivenClass(ItemList(range(3)))
class MyTests(MyFixture):

    @tags("normal-tag")
    def test_something(self):
        pass
```

When I run the above tests using the `-t normal-tag` flag, then all of the tests will run as you'd expect, but if I run tests using the `-t secret-tag` flag, then no tests are run. The same goes for decorators not being applied.

The proposed solution ensures that the tags and decorators applied to the `append_new_dataset()` method as parameters are correctly applied to tests when using `@DataDrivenFixture` or `@DataDrivenClass`.
